### PR TITLE
Basic refresh token realization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,8 @@ go.work
 go.work.sum
 
 # env file
-configs/*
+config.yaml
+configs/
 .env
 
 # Editor/IDE

--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -1,8 +1,8 @@
-port: "8000"
+port: "22000"
 
 db:
   username: "postgres"
-  host: "localhost"
-  port: "22001"
-  dbname: "postgres"
+  host: "db"
+  port: "5432"
+  dbname: "druna_db"
   sslmode: "disable"

--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -26,6 +26,7 @@ func (h *Handler) InitRoutes() *gin.Engine {
 	{
 		auth.POST("/sign-up", h.signUp)
 		auth.POST("/sign-in", h.signIn)
+		auth.POST("/renew-token", h.renewToken)
 	}
 
 	api := router.Group("/api", h.userIdentity)

--- a/pkg/handler/middleware.go
+++ b/pkg/handler/middleware.go
@@ -30,7 +30,7 @@ func (h *Handler) userIdentity(c *gin.Context) {
 		return
 	}
 
-	userId, err := h.services.Authorization.ParseToken(headerParts[1])
+	userId, _, err := h.services.Authorization.ParseToken(headerParts[1])
 	if err != nil {
 		NewErrorResponse(c, http.StatusUnauthorized, err.Error())
 		return

--- a/pkg/service/auth.go
+++ b/pkg/service/auth.go
@@ -12,13 +12,15 @@ import (
 )
 
 const (
-	signingKey = "jgfdi4trgdffdgdf"
-	tokenTTL   = 12 * time.Hour
+	signingKey      = "jgfdi4trgdffdgdf"
+	accessTokenTTL  = 1 * time.Minute
+	refreshTokenTTL = 7 * 24 * time.Hour
 )
 
 type tokenClaims struct {
 	jwt.StandardClaims
-	UserID int `json:"user_id"`
+	UserID   int    `json:"user_id"`
+	Username string `json:"username"`
 }
 
 type AuthService struct {
@@ -34,24 +36,72 @@ func (s *AuthService) CreateUser(user model.User) (int, error) {
 	return s.repo.CreateUser(user)
 }
 
-func (s *AuthService) GenerateToken(username, passwordHash string) (string, error) {
-	user, err := s.repo.GetUser(username, generatePasswordHash(passwordHash))
-	if err != nil {
-		return "", err
-	}
-
+func (s *AuthService) GenerateToken(tokenTTL time.Duration, user model.User) (string, error) {
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, &tokenClaims{
 		jwt.StandardClaims{
 			ExpiresAt: time.Now().Add(tokenTTL).Unix(),
 			IssuedAt:  time.Now().Unix(),
 		},
 		user.ID,
+		user.Username,
 	})
-
 	return token.SignedString([]byte(signingKey))
 }
 
-func (s *AuthService) ParseToken(accessToken string) (int, error) {
+func (s *AuthService) GenerateAccessRefreshToken(username, passwordHash string) (string, string, error) {
+	user, err := s.repo.GetUser(username, generatePasswordHash(passwordHash))
+	if err != nil {
+		return "", "", err
+	}
+
+	accessToken, err := s.GenerateToken(accessTokenTTL, user)
+	if err != nil {
+		return "", "", err
+	}
+
+	refreshToken, err := s.GenerateToken(refreshTokenTTL, user)
+	if err != nil {
+		return "", "", err
+	}
+
+	return accessToken, refreshToken, nil
+}
+
+/*
+	func (s *AuthService) GenerateRefreshToken(username, passwordHash string) (string, error) {
+		user, err := s.repo.GetUser(username, generatePasswordHash(passwordHash))
+		if err != nil {
+			return "", err
+		}
+
+		refreshToken, err := s.GenerateToken(refreshTokenTTL, user)
+		if err != nil {
+			return "", err
+		}
+
+		return refreshToken, nil
+	}
+*/
+func (s *AuthService) RenewToken(username string, userid int) (string, string, error) {
+	user := model.User{
+		ID:       userid,
+		Username: username,
+	}
+
+	newAccessToken, err := s.GenerateToken(accessTokenTTL, user)
+	if err != nil {
+		return "", "", err
+	}
+
+	newRefreshToken, err := s.GenerateToken(refreshTokenTTL, user)
+	if err != nil {
+		return "", "", err
+	}
+
+	return newAccessToken, newRefreshToken, nil
+}
+
+func (s *AuthService) ParseToken(accessToken string) (int, string, error) {
 	token, err := jwt.ParseWithClaims(accessToken, &tokenClaims{}, func(token *jwt.Token) (interface{}, error) {
 		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
 			return nil, errors.New("invalid signing method")
@@ -60,15 +110,15 @@ func (s *AuthService) ParseToken(accessToken string) (int, error) {
 		return []byte(signingKey), nil
 	})
 	if err != nil {
-		return 0, err
+		return 0, "", err
 	}
 
 	claims, ok := token.Claims.(*tokenClaims)
 	if !ok {
-		return 0, errors.New("token claims are not of type *tokenClaims")
+		return 0, "", errors.New("token claims are not of type *tokenClaims")
 	}
 
-	return claims.UserID, nil
+	return claims.UserID, claims.Username, nil
 }
 
 func generatePasswordHash(password string) string {

--- a/pkg/service/auth.go
+++ b/pkg/service/auth.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	signingKey      = "jgfdi4trgdffdgdf"
-	accessTokenTTL  = 1 * time.Minute
+	accessTokenTTL  = 12 * time.Hour
 	refreshTokenTTL = 7 * 24 * time.Hour
 )
 

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -3,12 +3,16 @@ package service
 import (
 	"druna_server/pkg/model"
 	"druna_server/pkg/repository"
+	"time"
 )
 
 type Authorization interface {
 	CreateUser(user model.User) (int, error)
-	GenerateToken(username, passwordHash string) (string, error)
-	ParseToken(token string) (int, error)
+	GenerateToken(tokenTTL time.Duration, user model.User) (string, error)
+	GenerateAccessRefreshToken(username, passwordHash string) (string, string, error)
+	//GenerateRefreshToken(username, passwordHash string) (string, error)
+	ParseToken(token string) (int, string, error)
+	RenewToken(username string, userid int) (string, string, error)
 }
 
 type User interface {


### PR DESCRIPTION
Super basic implementation of refresh token. When access token expires, client need to send a request to /auth/renew-token with "RefreshToken" field, and he will get a new pair of tokens as a response.
To-do: 
1.(!!!) Store refresh token somewhere (sql DB, Redis)
2. Make refresh token"revorcable"